### PR TITLE
T23208: Add GLib API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo FROM ubuntu:bionic > Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo ADD . /root >> Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo RUN apt-get update >> Dockerfile; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo RUN apt-get install -y meson ninja-build build-essential git >> Dockerfile; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo RUN apt-get install -y meson ninja-build build-essential git pkg-config libglib2.0-dev gir1.2-glib-2.0 gobject-introspection libgirepository1.0-dev >> Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t withgit .; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run withgit /bin/sh -c "cd /root && TRAVIS=true CC=$CC CXX=$CXX meson -Db_sanitize=address,undefined -Dwerror=true builddir && ninja -C builddir && G_SLICE=always-malloc ./builddir/tests/windowfx_wobbly_test --gtest_color=yes"; fi
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+libwobbly (0.3.1) eos; urgency=medium
+
+  * wobbly-glib: Add wobbly-glib library
+  * debian/control
+     - Add packaging for wobbly-glib0, wobbly-glib-dev, gir1.2-wobbly-glib
+
+ -- Sam Spilsbury <sam@endlessm.com>  Sat, 07 Jul 2018 02:26:53 +0800
+
 libwobbly (0.3.0) eos; urgency=medium
 
   * build: Port to Meson

--- a/debian/control
+++ b/debian/control
@@ -13,12 +13,36 @@ Package: libwobbly-dev
 Section: libdevel
 Architecture: any
 Depends: libwobbly0 (= ${binary:Version}),
-Description: Wobbly Mesh Library
- Wobbly Mesh
+Description: Wobbly Mesh Library (C++ API) headers
+ Wobbly Mesh (C++ API) headers
 
 Package: libwobbly0
 Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Wobbly Mesh library
+Description: Wobbly Mesh library (C++ API)
  Wobbly Mesh
+
+Package: libwobbly-glib0
+Section: libs
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, libwobbly0 (= ${binary:Version})
+Description: Wobbly Mesh library (GLib API)
+ Wobbly Mesh (GLib API)
+
+Package: libwobbly-glib-dev
+Section: libs
+Architecture: any
+Depends: libwobbly0 (= ${binary:Version}),
+Description: Wobbly Mesh library (GLib API) headers
+ Wobbly Mesh library (GLib API) headers
+
+Package: gir1.2-libwobbly-glib0
+Section: non-free/libs
+Architecture: any
+Depends: ${gir:Depends},
+         ${misc:Depends},
+         ${shlibs:Depends},
+         libwobbly-glib0
+Description: Wobbly Mesh library (GObject Introspection) files
+ Wobbly Mesh library (GObject Introspection) files

--- a/debian/gir1.2-libwobbly-glib0.install
+++ b/debian/gir1.2-libwobbly-glib0.install
@@ -1,0 +1,1 @@
+usr/lib/*/girepository-1.0/Wobbly-0.3.typelib

--- a/debian/libwobbly-dev.install
+++ b/debian/libwobbly-dev.install
@@ -1,2 +1,2 @@
-usr/include/*
-usr/lib/*/pkgconfig/*
+usr/include/wobbly/*
+usr/lib/*/pkgconfig/libwindowfx_wobbly-0.3.pc

--- a/debian/libwobbly-glib-dev.install
+++ b/debian/libwobbly-glib-dev.install
@@ -1,0 +1,3 @@
+usr/include/wobbly-glib/*
+usr/lib/*/pkgconfig/libwindowfx_wobbly_glib-0.3.pc
+usr/share/gir-1.0/Wobbly-0.3.gir

--- a/debian/libwobbly-glib0.install
+++ b/debian/libwobbly-glib0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libwindowfx_wobbly_glib.so*

--- a/meson.build
+++ b/meson.build
@@ -15,5 +15,6 @@ gtest_project = subproject('googletest')
 wobbly_inc = include_directories('.')
 
 subdir('wobbly')
+subdir('wobbly-glib')
 subdir('matchers')
 subdir('tests')

--- a/tests/glib_api_test.cpp
+++ b/tests/glib_api_test.cpp
@@ -1,0 +1,375 @@
+/*
+ * tests/glib_api_test.cpp
+ *
+ * Tests for the "wobbly" spring model, GObject API.
+ *
+ * See LICENCE.md for Copyright information.
+ */
+
+#include <iomanip>                      // for operator<<, setprecision
+#include <iosfwd>                       // for ostream
+#include <ostream>                      // for basic_ostream, char_traits, etc
+
+#include <wobbly-glib/anchor.h>
+#include <wobbly-glib/model.h>
+#include <wobbly-glib/vector.h>
+
+#include <mathematical_model_matcher.h>  // for Eq, EqDispatchHelper, etc
+#include <ostream_point_operator.h>      // for operator<<, etc
+#include <within_geometry_matcher.h>     // for WithinGeometry, etc
+
+#include <gmock/gmock-cardinalities.h>  // for AtLeast
+#include <gmock/gmock-generated-function-mockers.h>  // for FunctionMocker, etc
+#include <gmock/gmock-matchers.h>       // for AnythingMatcher, etc
+#include <gmock/gmock-spec-builders.h>  // for EXPECT_CALL, etc
+#include <gtest/gtest.h>                // for TEST_F, Test, Types, etc
+
+using ::testing::ElementsAreArray;
+using ::testing::Eq;
+using ::testing::Matcher;
+using ::testing::Not;
+using ::testing::Test;
+
+using ::wobbly::matchers::WithinGeometry;
+
+bool operator== (WobblyVector const &lhs,
+                 WobblyVector const &rhs)
+{
+  return lhs.x == rhs.x && lhs.y == rhs.y;
+}
+
+inline std::ostream &
+operator<< (std::ostream &lhs, WobblyVector const &v)
+{
+    return lhs << std::setprecision (10)
+               << "x: "
+               << v.x
+               << " y: "
+               << v.y;
+}
+
+namespace wobbly
+{
+    namespace geometry
+    {
+        namespace dimension
+        {
+            template <>
+            struct Dimension <WobblyVector>
+            {
+                typedef double data_type;
+                static const size_t dimensions = 2;
+            };
+
+            template <>
+            struct DimensionAccess <WobblyVector, 0>
+            {
+                static inline double get (WobblyVector const &p)
+                {
+                    return p.x;
+                }
+
+                static inline void
+                set (WobblyVector &p, double const &value)
+                {
+                    p.x = value;
+                }
+            };
+
+            template <>
+            struct DimensionAccess <WobblyVector, 1>
+            {
+                static inline double get (WobblyVector const &p)
+                {
+                    return p.y;
+                }
+
+                static inline void
+                set (WobblyVector &p, double const &value)
+                {
+                    p.y = value;
+                }
+            };
+        }
+    }
+}
+
+namespace
+{
+    namespace detail
+    {
+        template <typename T, typename U, typename Visitor, size_t N, size_t I>
+        struct ArrayMapInto
+        {
+            static void apply (std::array <T, N>       &dst,
+                               std::array <U, N> const &src,
+                               Visitor                 &&visitor)
+            {
+                dst[I] = visitor (src[I]);
+                ArrayMapInto <T, U, Visitor, N, I - 1>::apply (dst,
+                                                               src,
+                                                               std::forward <Visitor> (visitor));
+            }
+        };
+
+        template <typename T, typename U, typename Visitor, size_t N>
+        struct ArrayMapInto <T, U, Visitor, N, 0>
+        {
+            static void apply (std::array <T, N>       &dst,
+                               std::array <U, N> const &src,
+                               Visitor                 &&visitor)
+            {
+                dst[0] = visitor (src[0]);
+            }
+        };
+    }
+
+    template <typename T, typename U, typename Visitor, size_t N>
+    void array_map_into (std::array <T, N>       &dst,
+                         std::array <U, N> const &src,
+                         Visitor                 &&visitor)
+    {
+        detail::ArrayMapInto <T, U, Visitor, N, N - 1>::apply (dst,
+                                                               src,
+                                                               std::forward <Visitor> (visitor));
+    }
+
+    typedef wobbly::Box <wobbly::Point> PointBox;
+
+    TEST (WobblyGLibAPI, ConstructModel)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+    }
+
+    TEST (WobblyGLibAPI, MoveModelChangesExtremes)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+
+        std::array <WobblyVector, 4> extremes;
+
+        wobbly_model_move_to (model, { 1.0, 1.0 });
+        wobbly_model_query_extremes (model,
+                                     &extremes[0],
+                                     &extremes[1],
+                                     &extremes[2],
+                                     &extremes[3]);
+
+        std::array <WobblyVector, 4> expected = {
+            {
+                { 1.0, 1.0 },
+                { 101.0, 1.0 },
+                { 1.0, 101.0 },
+                { 101.0, 101.0 }
+            }
+        };
+        std::array <Matcher <WobblyVector const &>, 4> textureEdges;
+        array_map_into (textureEdges,
+                        expected,
+                        [](auto const &vector) -> decltype(auto) {
+                            return Eq (vector);
+                        });
+
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+    }
+
+    TEST (WobblyGLibAPI, ResizeModelChangesExtremes)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+
+        std::array <WobblyVector, 4> extremes;
+
+        wobbly_model_resize (model, { 200.0, 200.0 });
+        wobbly_model_query_extremes (model,
+                                     &extremes[0],
+                                     &extremes[1],
+                                     &extremes[2],
+                                     &extremes[3]);
+
+        std::array <WobblyVector, 4> expected = {
+            {
+                { 0.0, 0.0 },
+                { 200.0, 0.0 },
+                { 0.0, 200.0 },
+                { 200.0, 200.0 }
+            }
+        };
+        std::array <Matcher <WobblyVector const &>, 4> textureEdges;
+        array_map_into (textureEdges,
+                        expected,
+                        [](auto const &vector) -> decltype(auto) {
+                            return Eq (vector);
+                        });
+
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+    }
+
+    TEST (WobblyGLibAPI, GrabCorrectIndex)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+
+        wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+
+        WobblyVector topRightExtreme;
+        WobblyVector expectedTopRightExtreme = { 110.0, 0.0 };
+
+        wobbly_model_query_extremes (model,
+                                     nullptr,
+                                     &topRightExtreme,
+                                     nullptr,
+                                     nullptr);
+
+        EXPECT_THAT (topRightExtreme, Eq (expectedTopRightExtreme));
+    }
+
+    TEST (WobblyGLibAPI, ModelSettlesAfterMovingAnchor)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+
+        /* Move anchor and settle */
+        wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+        while (wobbly_model_step (model, 1));
+
+        std::array <WobblyVector, 4> extremes;
+        wobbly_model_query_extremes (model,
+                                     &extremes[0],
+                                     &extremes[1],
+                                     &extremes[2],
+                                     &extremes[3]);
+
+        std::array <WobblyVector, 4> expected = {
+            {
+                { 10.0, 10.0 },
+                { 110.0, 10.0 },
+                { 10.0, 110.0 },
+                { 110.0, 110.0 }
+            }
+        };
+        std::array <Matcher <WobblyVector const &>, 4> textureEdges;
+        array_map_into (textureEdges,
+                        expected,
+                        [](auto const &vector) -> decltype(auto) {
+                            return Eq (vector);
+                        });
+
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+    }
+
+    TEST (WobblyGLibAPI, DeformedWithGrabbedAnchor)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+        WobblyVector deformed;
+        WobblyVector center = { 50.0, 50.0 };
+
+        wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+        wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+
+        EXPECT_THAT (deformed, Not (Eq (center)));
+    }
+
+    TEST (WobblyGLibAPI, DeformedWithInsertAnchor)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_insert_anchor (model, { 70.0, 0.0 });
+        WobblyVector deformed;
+        WobblyVector center = { 50.0, 50.0 };
+
+        wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+        wobbly_model_step (model, 1);
+        wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+
+        EXPECT_THAT (deformed, Not (Eq (center)));
+    }
+
+    TEST (WobblyGLibAPI, NoDeformationNoAnchorMove)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+        WobblyVector deformed;
+        WobblyVector center = { 50.0, 50.0 };
+
+        wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+
+        EXPECT_THAT (deformed, Eq (center));
+    }
+
+    TEST (WobblyGLibAPI, ReleaseAnchorOnModel)
+    {
+        g_autoptr(WobblyModel) model = wobbly_model_new ({ 0.0, 0.0 },
+                                                         { 100.0, 100.0 },
+                                                         8.0,
+                                                         5.0,
+                                                         500.0);
+        g_autoptr(WobblyAnchor) anchor = wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+
+        /* Temporarily grab another anchor and move the first one */
+        {
+            g_autoptr(WobblyAnchor) otherAnchor = wobbly_model_grab_anchor (model, { 0.0, 0.0 });
+            wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+        }
+
+        /* Anchor is now released. Settle model */
+        while (wobbly_model_step (model, 1));
+
+        std::array <WobblyVector, 4> extremes;
+        wobbly_model_query_extremes (model,
+                                     &extremes[0],
+                                     &extremes[1],
+                                     &extremes[2],
+                                     &extremes[3]);
+
+        std::array <WobblyVector, 4> expected = {
+            {
+                { 10.0, 10.0 },
+                { 110.0, 10.0 },
+                { 10.0, 110.0 },
+                { 110.0, 110.0 }
+            }
+        };
+        std::array <Matcher <WobblyVector const &>, 4> textureEdges;
+        array_map_into (textureEdges,
+                        expected,
+                        [](auto const &vector) -> decltype(auto) {
+                            return WithinGeometry (PointBox (wobbly::Point (vector.x - 3.0,
+                                                                            vector.y - 3.0),
+                                                             wobbly::Point (vector.x + 3.0,
+                                                                            vector.y + 3.0)));
+                        });
+
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+    }
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@
 wobbly_test_sources = [
   'anchor_test.cpp',
   'constrainment_test.cpp',
+  'glib_api_test.cpp',
   'euler_integration_test.cpp',
   'mesh_interpolation_test.cpp',
   'model_test.cpp',
@@ -15,6 +16,9 @@ wobbly_test_sources = [
   'spring_test.cpp'
 ]
 
+glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
+
 wobbly_test_executable = executable(
   'windowfx_wobbly_test',
   wobbly_test_sources,
@@ -22,9 +26,12 @@ wobbly_test_executable = executable(
     gtest_project.get_variable('gtest_main_dep'),
     gtest_project.get_variable('gtest_dep'),
     gtest_project.get_variable('gmock_dep'),
+    glib,
+    gobject,
     mathematical_model_matcher_dep,
     within_geometry_matcher_dep,
-    wobbly_dep
+    wobbly_dep,
+    wobbly_glib_dep
   ]
 )
 

--- a/wobbly-glib/anchor.cpp
+++ b/wobbly-glib/anchor.cpp
@@ -1,0 +1,104 @@
+/*
+ * wobbly-glib/anchor.cpp
+ *
+ * GObject Interface for "wobbly" textures, Anchor
+ * type implementation.
+ *
+ * See LICENCE.md for Copyright information
+ */
+
+#include <wobbly-glib/anchor.h>
+
+#include <wobbly/wobbly.h>
+
+#include "wobbly-anchor-private.h"
+
+struct _WobblyAnchor
+{
+  GObject parent_instance;
+};
+
+typedef struct _WobblyAnchorPrivate
+{
+  wobbly::Anchor *anchor;
+} WobblyAnchorPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (WobblyAnchor,
+                            wobbly_anchor,
+                            G_TYPE_OBJECT);
+
+/**
+ * wobbly_anchor_move_by:
+ * @anchor: A #WobblyAnchor
+ * @vector: A #WobblyVector to move the anchor by
+ *
+ * Move the anchor by @vector, causing force to be exerted
+ * on the underlying anchor's model.
+ */
+void
+wobbly_anchor_move_by (WobblyAnchor *anchor,
+                       WobblyVector  vector)
+{
+  WobblyAnchorPrivate *priv =
+    reinterpret_cast <WobblyAnchorPrivate *> (wobbly_anchor_get_instance_private (anchor));
+
+  if (priv->anchor != nullptr)
+    priv->anchor->MoveBy (wobbly::Point (vector.x, vector.y));
+}
+
+
+/**
+ * wobbly_anchor_release:
+ * @anchor: A #WobblyAnchor
+ *
+ * Release the anchor, allowing the relevant control points
+ * to move freely and have force exerted on them. Attempting
+ * to move the anchor past this point is inert.
+ */
+void
+wobbly_anchor_release (WobblyAnchor *anchor)
+{
+  WobblyAnchorPrivate *priv =
+    reinterpret_cast <WobblyAnchorPrivate *> (wobbly_anchor_get_instance_private (anchor));
+
+  if (priv->anchor != nullptr)
+    {
+      delete priv->anchor;
+      priv->anchor = nullptr;
+    }
+}
+
+static void
+wobbly_anchor_finalize (GObject *object)
+{
+  WobblyAnchor *anchor = WOBBLY_ANCHOR (object);
+
+  wobbly_anchor_release (anchor);
+}
+
+static void
+wobbly_anchor_init (WobblyAnchor *store)
+{
+}
+
+
+static void
+wobbly_anchor_class_init (WobblyAnchorClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = wobbly_anchor_finalize;
+}
+
+WobblyAnchor *
+wobbly_anchor_new_for_native_anchor_rvalue (wobbly::Anchor &&anchor)
+{
+  WobblyAnchor *anchor_object =
+    WOBBLY_ANCHOR (g_object_new (WOBBLY_TYPE_ANCHOR, NULL));
+  WobblyAnchorPrivate *priv =
+    reinterpret_cast <WobblyAnchorPrivate *> (wobbly_anchor_get_instance_private (anchor_object));
+
+  priv->anchor = new wobbly::Anchor (std::move (anchor));
+
+  return anchor_object;
+}

--- a/wobbly-glib/anchor.h
+++ b/wobbly-glib/anchor.h
@@ -1,0 +1,32 @@
+/*
+ * wobbly-glib/anchor.h
+ *
+ * GObject Interface for "wobbly" textures, Anchor type.
+ *
+ * An anchor is an object type privately holding an
+ * anchor. The owner can release the anchor, which happens
+ * implicitly when its ref-count drops to zero or when
+ * the release() method is called.
+ *
+ * See LICENCE.md for Copyright information
+ */
+#ifndef WOBBLY_GLIB_ANCHOR_H
+#define WOBBLY_GLIB_ANCHOR_H
+
+#include <glib-object.h>
+
+#include <wobbly-glib/vector.h>
+
+G_BEGIN_DECLS
+
+#define WOBBLY_TYPE_ANCHOR wobbly_anchor_get_type ()
+G_DECLARE_FINAL_TYPE (WobblyAnchor, wobbly_anchor, WOBBLY, ANCHOR, GObject)
+
+void wobbly_anchor_move_by (WobblyAnchor *anchor,
+                            WobblyVector  vector);
+
+void wobbly_anchor_release (WobblyAnchor *anchor);
+
+G_END_DECLS
+
+#endif

--- a/wobbly-glib/meson.build
+++ b/wobbly-glib/meson.build
@@ -1,0 +1,68 @@
+# /wobbly-glib/meson.build
+#
+# Build the libwobbly library.
+#
+# See /LICENCE.md for Copyright information.
+
+api_version = '0.3'
+
+wobbly_introspectable_sources = [
+  'anchor.cpp',
+  'model.cpp',
+  'vector.cpp'
+]
+
+wobbly_sources = wobbly_introspectable_sources + [
+  'wobbly-anchor-private.h'
+]
+
+wobbly_headers = [
+  'anchor.h',
+  'model.h',
+  'vector.h'
+]
+
+glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
+
+wobbly_glib_lib = shared_library(
+  'windowfx_wobbly_glib',
+  wobbly_sources,
+  soversion: api_version,
+  install: true,
+  include_directories: [ wobbly_inc ],
+  dependencies: [ glib, gobject, wobbly_dep ]
+)
+
+install_headers(wobbly_headers, subdir: 'wobbly-glib')
+
+wobbly_glib_dep = declare_dependency(
+  link_with: wobbly_glib_lib,
+  include_directories: [ wobbly_inc ],
+)
+
+introspection_sources = [ wobbly_introspectable_sources, wobbly_headers ]
+
+gnome = import('gnome')
+gnome.generate_gir(
+  wobbly_glib_lib,
+  extra_args: ['--warn-all', '--warn-error'],
+  identifier_prefix: 'Wobbly',
+  include_directories: wobbly_inc,
+  includes: ['GLib-2.0', 'GObject-2.0'],
+  install: true,
+  namespace: 'Wobbly',
+  nsversion: api_version,
+  sources: introspection_sources,
+  symbol_prefix: 'wobbly'
+)
+
+pkg = import('pkgconfig')
+pkg.generate(
+  description: 'Library to provide a spring-controlled bezier mesh (GObject Binding)',
+  name: 'libwindowfx_wobbly_glib',
+  filebase: 'libwindowfx_wobbly_glib-' + api_version,
+  version: meson.project_version(),
+  libraries: wobbly_glib_lib,
+  install_dir: join_paths(get_option('libdir'), 'pkgconfig')
+)

--- a/wobbly-glib/model.cpp
+++ b/wobbly-glib/model.cpp
@@ -1,0 +1,447 @@
+/*
+ * wobbly-glib/wobbly.cpp
+ *
+ * GObject Interface for "wobbly" textures
+ *
+ * See LICENCE.md for Copyright information
+ */
+
+#include <wobbly-glib/anchor.h>
+#include <wobbly-glib/model.h>
+#include <wobbly-glib/vector.h>
+
+#include <wobbly/wobbly.h>
+
+#include "wobbly-anchor-private.h"
+
+struct _WobblyModel
+{
+  GObject parent_instance;
+};
+
+typedef struct _WobblyModelPrivate
+{
+  wobbly::Model::Settings  settings;
+  wobbly::Model           *model;
+
+  /* We need to keep track of these during
+   * construction while model isn't set */
+  WobblyVector             prop_position;
+  WobblyVector             prop_size;
+} WobblyModelPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (WobblyModel,
+                            wobbly_model,
+                            G_TYPE_OBJECT)
+
+enum {
+  PROP_0,
+  PROP_SPRING_K,
+  PROP_FRICTION,
+  PROP_MAXIMUM_RANGE,
+  PROP_POSITION,
+  PROP_SIZE,
+  NPROPS
+};
+
+static GParamSpec *wobbly_model_props [NPROPS] = { NULL, };
+
+namespace wgd = wobbly::geometry::dimension;
+
+/**
+ * wobbly_model_grab_anchor:
+ * @model: A #WobblyModel
+ * @position: A #WobblyVector specifying the position in absolute space
+ *            where the closest object in the mesh should be grabbed.
+ *
+ * Grab the closest control point in the mesh to @position and
+ * return it as a #WobblyAnchor. The control point will not have spring
+ * force exerted upon it, though other control points will have forces
+ * exerted on them by the anchored control point.
+ *
+ * The control point remains grabbed until wobbly_anchor_release() is
+ * called on the anchor, or the anchor is destroyed.
+ *
+ * Returns: (transfer full): A #WobblyAnchor controlling the closest control
+ *                           point to @position.
+ */
+WobblyAnchor *
+wobbly_model_grab_anchor (WobblyModel *model,
+                          WobblyVector position)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+  wobbly::Anchor anchor (priv->model->GrabAnchor (wobbly::Point (position.x,
+                                                                 position.y)));
+
+  return wobbly_anchor_new_for_native_anchor_rvalue (std::move (anchor));
+}
+
+/**
+ * wobbly_model_insert_anchor:
+ * @model: A #WobblyModel
+ * @position: A #WobblyVector specifying the position in absolute space
+ *            where the anchoring control point should be inserted
+ *
+ * Insert a new control point into the mesh at @position and split the
+ * closest spring to it in half, with both halves attaching to the
+ * inserted control point. The control point will not have spring
+ * force exerted upon it, though other control points will have forces
+ * exerted on them by the anchored control point.
+ *
+ * The control point remains in place until wobbly_anchor_release() is
+ * called on the anchor, or the anchor is destroyed.
+ *
+ * Returns: (transfer full): A #WobblyAnchor controlling the inserted control
+ *                           at @position.
+ */
+WobblyAnchor *
+wobbly_model_insert_anchor (WobblyModel *model,
+                            WobblyVector position)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+  wobbly::Anchor anchor (priv->model->InsertAnchor (wobbly::Point (position.x,
+                                                                   position.y)));
+
+  return wobbly_anchor_new_for_native_anchor_rvalue (std::move (anchor));
+}
+
+/**
+ * wobbly_model_step:
+ * @model: A #WobblyModel
+ * @ms: Time period to integrate over.
+ *
+ * Compute all the instantaneous forces exerted by springs in the
+ * mesh and integrate over @ms to determine the velocities and
+ * changes in model control point positions.
+ *
+ * Returns: %TRUE if further integration is required, %FALSE otherwise.
+ */
+gboolean
+wobbly_model_step (WobblyModel  *model,
+                   unsigned int  ms)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  return priv->model->Step (ms);
+}
+
+/**
+ * wobbly_model_deform_texcoords:
+ * @model: A #WobblyModel
+ * @uv: A #WobblyVector specifying the unit coordinates relative to
+ *      the top right corner of a square to be deformed.
+ * @deformed: (out caller-allocates): A #WobblyVector specifying the
+ *             absolute position in space that the unit co-ordinate would
+ *             be deformed to.
+ *
+ * Deform texture-coordinates into real space according to the model.
+ */
+void
+wobbly_model_deform_texcoords (WobblyModel  *model,
+                               WobblyVector  uv,
+                               WobblyVector *deformed)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  g_return_if_fail (deformed != NULL);
+
+  wobbly::Point deformed_point (priv->model->DeformTexcoords (wobbly::Point (uv.x, uv.y)));
+  *deformed = {
+    wobbly::geometry::dimension::get <0> (deformed_point),
+    wobbly::geometry::dimension::get <1> (deformed_point)
+  };
+}
+
+/**
+ * wobbly_model_deform_query_extremes:
+ * @model: A #WobblyModel
+ * @uv: A #WobblyVector specifying the unit coordinates relative to
+ *      the top right corner of a square to be deformed.
+ * @top_left: (out caller-allocates): The top left extreme.
+ * @top_right: (out caller-allocates): The top right extreme.
+ * @bottom_left: (out caller-allocates): The bottom left extreme.
+ * @bottom_right: (out caller-allocates): The bottom right extreme.
+ *
+ * Query the bounding 4-vertex polygon around the model.
+ */
+void
+wobbly_model_query_extremes (WobblyModel  *model,
+                             WobblyVector *top_left,
+                             WobblyVector *top_right,
+                             WobblyVector *bottom_left,
+                             WobblyVector *bottom_right)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  std::array <wobbly::Point, 4> extremes (priv->model->Extremes ());
+
+  if (top_left != nullptr)
+    *top_left = { wgd::get <0> (extremes[0]), wgd::get <1> (extremes[0]) };
+
+  if (top_right != nullptr)
+    *top_right = { wgd::get <0> (extremes[1]), wgd::get <1> (extremes[1]) };
+
+  if (bottom_left != nullptr)
+    *bottom_left = { wgd::get <0> (extremes[2]), wgd::get <1> (extremes[2]) };
+
+  if (bottom_right != nullptr)
+    *bottom_right = { wgd::get <0> (extremes[3]), wgd::get <1> (extremes[3]) };
+}
+
+/**
+ * wobbly_model_move_to:
+ * @model: A #WobblyModel
+ * @position: A #WobblyVector to move the top right corner to.
+ *
+ * Move the entire model to have its top right corner at @position
+ * without causing any deformation.
+ */
+void
+wobbly_model_move_to (WobblyModel *model,
+                      WobblyVector position)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->prop_position = position;
+
+  if (priv->model != nullptr)
+    priv->model->MoveModelTo (wobbly::Point (position.x, position.y));
+}
+
+/**
+ * wobbly_model_move_by:
+ * @model: A #WobblyModel
+ * @delta: A #WobblyVector to move the top right corner by.
+ *
+ * Move the entire model by @position without causing any deformation.
+ */
+void
+wobbly_model_move_by (WobblyModel *model,
+                      WobblyVector delta)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->prop_position.x += delta.x;
+  priv->prop_position.y += delta.y;
+
+  if (priv->model != nullptr)
+    priv->model->MoveModelBy (wobbly::Point (delta.x, delta.y));
+}
+
+/**
+ * wobbly_model_resize:
+ * @model: A #WobblyModel
+ * @size: A #WobblyVector specifying the size in each dimension.
+ *
+ * Resize the model according to @size.
+ */
+void
+wobbly_model_resize (WobblyModel *model,
+                     WobblyVector size)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->prop_size = size;
+
+  if (priv->model != nullptr)
+    priv->model->ResizeModel (size.x, size.y);
+}
+
+void
+wobbly_model_set_spring_k (WobblyModel *model,
+                           double       spring_constant)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->settings.springConstant = spring_constant;
+}
+
+void
+wobbly_model_set_friction (WobblyModel *model,
+                           double       friction)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->settings.friction = friction;
+}
+
+void
+wobbly_model_set_maximum_range (WobblyModel *model,
+                                double       range)
+{
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->settings.maximumRange = range;
+}
+
+static void
+wobbly_model_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  WobblyModel *model = WOBBLY_MODEL (object);
+
+  switch (prop_id)
+    {
+    case PROP_SPRING_K:
+      wobbly_model_set_spring_k (model, g_value_get_double (value));
+      break;
+    case PROP_FRICTION:
+      wobbly_model_set_friction (model, g_value_get_double (value));
+      break;
+    case PROP_MAXIMUM_RANGE:
+      wobbly_model_set_maximum_range (model, g_value_get_double (value));
+      break;
+    case PROP_POSITION:
+      wobbly_model_move_to (model, *(reinterpret_cast <WobblyVector *> (g_value_get_boxed (value))));
+      break;
+    case PROP_SIZE:
+      wobbly_model_resize (model, *(reinterpret_cast <WobblyVector *> (g_value_get_boxed (value))));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+wobbly_model_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  WobblyModel *model = WOBBLY_MODEL (object);
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  switch (prop_id)
+    {
+    case PROP_SPRING_K:
+      g_value_set_double (value, priv->settings.springConstant);
+      break;
+    case PROP_FRICTION:
+      g_value_set_double (value, priv->settings.friction);
+      break;
+    case PROP_MAXIMUM_RANGE:
+      g_value_set_double (value, priv->settings.maximumRange);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+wobbly_model_finalize (GObject *object)
+{
+  WobblyModel *model = WOBBLY_MODEL (object);
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  delete priv->model;
+  priv->model = nullptr;
+
+  G_OBJECT_CLASS (wobbly_model_parent_class)->finalize (object);
+}
+
+static void
+wobbly_model_constructed (GObject *object)
+{
+  WobblyModel *model = WOBBLY_MODEL (object);
+  WobblyModelPrivate *priv =
+    reinterpret_cast <WobblyModelPrivate *> (wobbly_model_get_instance_private (model));
+
+  priv->model = new wobbly::Model (wobbly::Point (priv->prop_position.x,
+                                                  priv->prop_position.y),
+                                   priv->prop_size.x,
+                                   priv->prop_size.y,
+                                   priv->settings);
+}
+
+static void
+wobbly_model_init (WobblyModel *model)
+{
+}
+
+
+static void
+wobbly_model_class_init (WobblyModelClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed = wobbly_model_constructed;
+  object_class->get_property = wobbly_model_get_property;
+  object_class->set_property = wobbly_model_set_property;
+  object_class->finalize = wobbly_model_finalize;
+
+  wobbly_model_props[PROP_SPRING_K] =
+    g_param_spec_double ("spring-k",
+                         "Spring Constant",
+                         "Multiplier for force exerted by springs",
+                         0.1,
+                         10.0,
+                         wobbly::Model::DefaultSpringConstant,
+                         static_cast <GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+
+  wobbly_model_props[PROP_FRICTION] =
+    g_param_spec_double ("friction",
+                         "Friction Constant",
+                         "Multiplier for friction exerted by springs",
+                         0.1,
+                         10.0,
+                         wobbly::Model::Friction,
+                         static_cast <GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+
+  wobbly_model_props[PROP_MAXIMUM_RANGE] =
+    g_param_spec_double ("movement-range",
+                         "Object Movement Range",
+                         "How far away connected points can be from their rest point",
+                         10.0,
+                         1000.0,
+                         wobbly::Model::DefaultObjectRange,
+                         static_cast <GParamFlags> (G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+
+  wobbly_model_props[PROP_POSITION] =
+    g_param_spec_boxed ("position",
+                        "Model position",
+                        "Where the model is in absolute 2D space",
+                        WOBBLY_TYPE_VECTOR,
+                        static_cast <GParamFlags> (G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
+
+  wobbly_model_props[PROP_SIZE] =
+    g_param_spec_boxed ("size",
+                        "Model size",
+                        "Where how big the model is in 2D space",
+                        WOBBLY_TYPE_VECTOR,
+                        static_cast <GParamFlags> (G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
+
+  g_object_class_install_properties (object_class,
+                                     NPROPS,
+                                     wobbly_model_props);
+}
+
+WobblyModel *
+wobbly_model_new (WobblyVector position,
+                  WobblyVector size,
+                  double       spring_constant,
+                  double       friction,
+                  double       maximum_range)
+{
+  return WOBBLY_MODEL (g_object_new (WOBBLY_TYPE_MODEL,
+                                     "spring-k", spring_constant,
+                                     "friction", friction,
+                                     "movement-range", maximum_range,
+                                     "position", &position,
+                                     "size", &size,
+                                     nullptr));
+}

--- a/wobbly-glib/model.h
+++ b/wobbly-glib/model.h
@@ -1,0 +1,62 @@
+/*
+ * wobbly-glib/model.h
+ *
+ * GObject Interface for "wobbly" textures
+ *
+ * See LICENCE.md for Copyright information
+ */
+#ifndef WOBBLY_GLIB_MODEL_H
+#define WOBBLY_GLIB_MODEL_H
+
+#include <glib-object.h>
+
+#include <wobbly-glib/anchor.h>
+#include <wobbly-glib/vector.h>
+
+G_BEGIN_DECLS
+
+#define WOBBLY_TYPE_MODEL wobbly_model_get_type ()
+G_DECLARE_FINAL_TYPE (WobblyModel, wobbly_model, WOBBLY, MODEL, GObject)
+
+WobblyModel * wobbly_model_new (WobblyVector  position,
+                                WobblyVector  size,
+                                double        spring_constant,
+                                double        friction,
+                                double        maximum_range);
+
+WobblyAnchor * wobbly_model_grab_anchor (WobblyModel *model,
+                                         WobblyVector position);
+
+WobblyAnchor * wobbly_model_insert_anchor (WobblyModel *model,
+                                           WobblyVector position);
+
+gboolean wobbly_model_step (WobblyModel  *model,
+                            unsigned int  ms);
+
+void wobbly_model_deform_texcoords (WobblyModel  *model,
+                                    WobblyVector  uv,
+                                    WobblyVector *deformed);
+
+void wobbly_model_query_extremes (WobblyModel  *model,
+                                  WobblyVector *top_left,
+                                  WobblyVector *top_right,
+                                  WobblyVector *bottom_left,
+                                  WobblyVector *bottom_right);
+
+void wobbly_model_move_to (WobblyModel *model,
+                           WobblyVector position);
+void wobbly_model_move_by (WobblyModel *model,
+                           WobblyVector delta);
+
+void wobbly_model_resize (WobblyModel *model,
+                          WobblyVector size);
+
+void wobbly_model_set_spring_k (WobblyModel *model, double spring_constant);
+
+void wobbly_model_set_friction (WobblyModel *model, double friction);
+
+void wobbly_model_set_maximum_range (WobblyModel *model, double range);
+
+G_END_DECLS
+
+#endif

--- a/wobbly-glib/vector.cpp
+++ b/wobbly-glib/vector.cpp
@@ -1,0 +1,26 @@
+/*
+ * wobbly-glib/vector.cpp
+ *
+ * GObject Interface for "wobbly" textures, vector
+ * type implementation.
+ *
+ * See LICENCE.md for Copyright information
+ */
+
+#include <wobbly-glib/vector.h>
+
+static gpointer
+wobbly_vector_copy (gpointer ptr)
+{
+  WobblyVector *src = reinterpret_cast <WobblyVector *> (ptr);
+  WobblyVector *dst = g_new0 (WobblyVector, 1);
+
+  *dst = *src;
+
+  return reinterpret_cast <gpointer> (dst);
+}
+
+G_DEFINE_BOXED_TYPE (WobblyVector,
+                     wobbly_vector,
+                     wobbly_vector_copy,
+                     g_free);

--- a/wobbly-glib/vector.h
+++ b/wobbly-glib/vector.h
@@ -1,0 +1,26 @@
+/*
+ * wobbly-glib/vector.h
+ *
+ * GObject Interface for "wobbly" textures, 2D vector type
+ *
+ * See LICENCE.md for Copyright information
+ */
+#ifndef WOBBLY_GLIB_VECTOR_H
+#define WOBBLY_GLIB_VECTOR_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+typedef struct {
+  double x;
+  double y;
+} WobblyVector;
+
+#define WOBBLY_TYPE_VECTOR wobbly_vector_get_type ()
+
+GType wobbly_vector_get_type ();
+
+G_END_DECLS
+
+#endif

--- a/wobbly-glib/wobbly-anchor-private.h
+++ b/wobbly-glib/wobbly-anchor-private.h
@@ -1,0 +1,21 @@
+/*
+ * wobbly-glib/anchor-private.h
+ *
+ * GObject Interface for "wobbly" textures, Anchor type.
+ *
+ * An anchor is an object type privately holding an
+ * anchor. The owner can release the anchor, which happens
+ * implicitly when its ref-count drops to zero or when
+ * the release() method is called.
+ *
+ * See LICENCE.md for Copyright information
+ */
+
+#include <wobbly/wobbly.h>
+
+#ifndef WOBBLY_GLIB_ANCHOR_PRIVATE_H
+#define WOBBLY_GLIB_ANCHOR_PRIVATE_H
+
+WobblyAnchor * wobbly_anchor_new_for_native_anchor_rvalue (wobbly::Anchor &&anchor);
+
+#endif


### PR DESCRIPTION
Add a GLib API to libwobbly so that it can be more easily used from language bindings.

https://phabricator.endlessm.com/T23208